### PR TITLE
update .tmux.conf because of tmux upgrade 3.0a

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,37 +1,37 @@
 #Use something easier to type as the prefix
 set -g prefix `
 unbind C-b
-bind "'" send-prefix
+bind-key "'" send-prefix
 
 # Mouse behavior use version 2.1 up
 set -g mouse on
 
-bind - split-window -v
-bind \ split-window -h
+bind-key "-" split-window -h -c '#{pane_current_path}'  # Split panes horizontal
+bind-key "\\" split-window -v -c '#{pane_current_path}'  # Split panes vertically
 
 # Fast choose pane
-bind ` last-window
-bind c new-window -a
+bind-key ` last-window
+bind-key c new-window -a
 
 # Pane movement
-bind j select-pane -t :.+
-bind k select-pane -t :.-
-bind h select-window -p
-bind l next-window
-bind Left select-window -p
-bind Right next-window
+bind-key j select-pane -t :.+
+bind-key k select-pane -t :.-
+bind-key h select-window -p
+bind-key l next-window
+bind-key Left select-window -p
+bind-key Right next-window
 
 # Pane resizing
-bind -r H resize-pane -L 5
-bind -r J resize-pane -D 5
-bind -r K resize-pane -U 5
-bind -r L resize-pane -R 5
+bind-key -r H resize-pane -L 5
+bind-key -r J resize-pane -D 5
+bind-key -r K resize-pane -U 5
+bind-key -r L resize-pane -R 5
 
-bind PageUp copy-mode -u
-bind PageDown copy-mode
+bind-key PageUp copy-mode -u
+bind-key PageDown copy-mode
 
-bind v copy-mode
-bind p paste-buffer -p
+bind-key v copy-mode
+bind-key p paste-buffer -p
 
 #set -g status-left "#{pane_current_path}"
 
@@ -44,12 +44,10 @@ set -g status-right-length 150
 
 set -g status-fg white
 set -g status-bg colour234
-set -g window-status-activity-attr bold
-set -g pane-border-fg colour245
-set -g pane-active-border-fg colour39
-set -g message-fg colour16
-set -g message-bg colour221
-set -g message-attr bold
+set -g status-style bold
+set -g pane-border-style fg=colour245
+set -g pane-active-border-style fg=colour39
+set -g message-style bg=colour221,fg=colour16,bold
 
 
 set -g default-command "reattach-to-user-namespace -l ${SHELL}"


### PR DESCRIPTION
# Problem
restart my computer and restart `tmux`

force this  error

``` bash
$ tmux
dyld: Library not loaded: /usr/local/lib/libevent-2.0.5.dylib
  Referenced from: /usr/local/bin/tmux
  Reason: image not found
```

Same as this `install tmux`  error
[Installing tmux but getting “dyld: Library not loaded Referenced from: /usr/”
](https://apple.stackexchange.com/questions/127186/installing-tmux-but-getting-dyld-library-not-loaded-referenced-from-usr)



# Reference & Fix :
I tried 
```
$ brew unlink libevent && brew link libevent
   Unlinking /usr/local/Cellar/libevent/2.0.21... 4 links removed
   Linking /usr/local/Cellar/libevent/2.0.21... 25 symlinks created
$ tmux -V
   dyld: Library not loaded: /usr/local/lib/libevent-2.0.5.dylib
   Referenced from: /usr/local/Cellar/tmux/1.9a/bin/tmux
   Reason: image not found
```
But still faild, then i tried :
```
$ brew uninstall --force tmux
$ brew install tmux
$ tmux -V
tmux 3.0a
```
Success but ...
![image](https://user-images.githubusercontent.com/18432952/72324467-fb50ab00-36e5-11ea-8810-6ed785853af5.png)

So  I found some references :

> https://github.com/tmux/tmux/issues/1990
> So, just change your config to
> bind-key \\ split-window -v -c '#{pane_current_path}' # Split panes vertically

and the plugin upgrade so need to change syntax

> [Tmux 2.8.X to 2.9.X migration ](https://github.com/tmux/tmux/issues/1689#issuecomment-486722349)
>These are the -style options:
>  .................
> The form is exactly the same, it is just one option instead of three:
> set -g mode-style bg=red,fg=green,blink
> same as this [git lab example](https://gitlab.com/fernandobasso/dotfiles/commit/af2c0ac59b93b318575367f0313ad1ca0627a6ba)

